### PR TITLE
Fix dependencies for Draconic injector quest

### DIFF
--- a/config/ftbquests/quests/chapters/draconic_evolution.snbt
+++ b/config/ftbquests/quests/chapters/draconic_evolution.snbt
@@ -580,7 +580,7 @@
 			description: ["The Draconic Fusion Crafting Injector is the third tier of Fusion Crafting Injectors used in the Fusion crafting process, they can get energy more quickly, so your craft in the Fusion Crafting Core can do more quickly."]
 			dependencies: [
 				"6AFF133E53B9E11E"
-				"7E6F43ABF03FF686"
+				"37E47BACAEEA6C1C"
 				"170B797FE3905864"
 			]
 			id: "16A5A3624601F22E"


### PR DESCRIPTION
In the actual quest we have to craft a Draconic core before the Draconic injector, but in fact it is the Wyvern Core :)
![image](https://github.com/MLDEG/Ragnamod_VII/assets/74428850/1a15ebcb-bf0b-4341-bb90-33eef146451d)
![image](https://github.com/MLDEG/Ragnamod_VII/assets/74428850/26a505c8-88ac-4c72-b0a8-459d4c0c22c6)
